### PR TITLE
Fix troff warnings in manpages

### DIFF
--- a/man/dst2ascii.1
+++ b/man/dst2ascii.1
@@ -6,19 +6,19 @@
 dst2ascii \- Convert DST record files to CSV
 .SH SYNOPSIS
 .B dst2ascii
-\n
+.br
 .B dst2ascii
 .B dst_directory
-\n
+.br
 .SH DESCRIPTION
 This is a small utility to convert the binary record file produced when performing
 distance calculations to an ASCII file for further analysis.
-\n
+.br
 Distance calculations are triggered by performing by using the filenames
 voacapd.dat and voacapd.out for voacap input/output files. e.g.
-\n
+.br
 voacapl ~/itshfbc voacapd.dat voacapd.output
-\n
+.br
 .SH OPTIONS
 .IP dst_directory
 The location of the .dst file and corresponding .idx file.  The output ASCII file
@@ -26,12 +26,12 @@ is saved in this directory.  If this parameter is not specified, the current
 working directory will be used.
 .SH EXAMPLES
 dst2ascii
-\n
+.br
 Creates an ASCII file (voacapd.asc) using the values found in the voacap.dst and
 voacapd.idx files located in the current working directory.
-\n
+.br
 dst2ascii my_directory
-\n
+.br
 Creates an ASCII file (my_directory/voacapd.asc) using the values found in
 the voacap.dst and voacapd.idx files located in the directory 'my_directory'.
 

--- a/man/dst2csv.1
+++ b/man/dst2csv.1
@@ -6,20 +6,20 @@
 dst2csv \- Convert DST record files to CSV
 .SH SYNOPSIS
 .B dst2csv
-\n
+.br
 .B dst2csv -i dst_directory
-\n
+.br
 .B dst2csv -d -i dst_directory
-\n
+.br
 .SH DESCRIPTION
 This is a small utility to convert the binary record file produced when performing
 distance calculations to a CSV file for further processing.
-\n
+.br
 Distance calculations are triggered by performing by using the filenames
 voacapd.dat and voacapd.out for voacap input/output files. e.g.
-\n
+.br
 voacapl ~/itshfbc voacapd.dat voacapd.out
-\n
+.br
 .SH OPTIONS
 .IP dst_directory
 The location of the .dst file and corresponding .idx file.  The output csv file
@@ -27,17 +27,17 @@ is saved in this directory.  If this parameter is not specified, the current
 working directory will be used.
 .SH EXAMPLES
 dst2csv
-\n
+.br
 Creates a CSV files (voacapd.csv) using the values found in the voacap.dst and
 voacapd.idx files located in the current working directory.
-\n
+.br
 dst2csv -i my_directory
-\n
+.br
 Creates a CSV file (my_directory/voacapd.csv) using the values found in the
 voacap.dst and voacapd.idx files located in the directory 'my_directory'.
-\n
+.br
 dst2csv -d -i my_directory
-\n
+.br
 Creates a CSV file (my_directory/voacapd.csv) using the values found in the
 voacap.dst and voacapd.idx files and a 'dump' file (my_directory/voacapd.dmp)
 

--- a/man/voacapl.1
+++ b/man/voacapl.1
@@ -8,20 +8,20 @@ voacapl \- HF propagation prediction program
 .B voacapl [\-s --silent --run-dir=directory_path --absorption-mode=mode]
 .B voacap_directory
 .I [inputfile]
-\n
+.br
 .B voacapl [\-s --silent --run-dir=directory_path --absorption-mode=mode]
 .B voacap_directory
 .I [inputfile outputfile]
-\n
+.br
 .B voacapl [\-s --silent --run-dir=directory_path --absorption-mode=mode]
 .I voacap_directory
 .B area calc
 .I [areafile]
-\n
+.br
 .B voacapl [\-s]
 .I voacap_directory
 .B batch
-\n
+.br
 .B voacapl \-v
 .SH DESCRIPTION
 An implementation of VOACAP, the NTIA/ITS professional HF propagation prediction
@@ -29,10 +29,10 @@ program, originally developed for the Voice of America (VOA).   VOACAP reads an
 input file and writes point-to-point path or area prediction data to an output
 file(s). 'voacapl' is a version of the original source that has been modified
 to enable compilation using GCC/GFortran.
-\n
+.br
 Only changes required to enable compilation using GCC have been made, the
 underlying prediction algorithms remain unchanged.
-\n
+.br
 Voacapl input/output files follow exactly the same format as VOACAP and are not described here.  Details of these file formats may be found at www.voacap.com.
 .SH OPTIONS
 .IP -s
@@ -48,7 +48,7 @@ concurrently and to facilitate clean-up after performing a prediction.
 .IP --absorption-mode
 Used to specify the absorption mode that should be used for the prediction, overriding
 the value defined in version.w32.  Valid values are 'W' (normal), 'I' (IONCAP),
-'A' (Alex's modifications with normal absorption) and 'a' (Alex's changes with
+\(aqA' (Alex's modifications with normal absorption) and 'a' (Alex's changes with
 IONCAP absorption).
 .IP voacap_directory
 Specifies the path to the itshfbc directory, e.g. '~/itshfbc/' or '/usr/share/itshfbc'.  Read/write access is required to the sub-directories below itshfbc.
@@ -64,22 +64,22 @@ operation of the VOAAREA operation.  voacapl currently only supports the 'calc' 
 File containing the input data for an area calculation.  The path to the areafile must be given relative to the 'itshfbc/areadata/' directory.
 .SH EXAMPLES
 voacapl ~/itshfbc
-\n
+.br
 Reads the default input file (~/itshfbc/run/voacapx.dat) performs a prediction calculation and saves the results in the default output
 file (~/itshfbc/run/voacapx.out).  In this example, the itshfbc directory is defined as a sub-directory of the users home folder.
 
 voacapl ~/itshfbc infile.dat outfile.out
-\n
+.br
 Reads infile.dat and save the results of the calculations in the file outfile.out.  Both of the files should be located in the directory '~/itshfbc/run'.
 
 voacapl --run-dir=/tmp/myrunndir ~/itshfbc infile.dat outfile.out
-\n
+.br
 Performs a prediction defined by infile.dat and saves the results of the calculations
 in the file outfile.out.  The input file should be placed in the directory defined by the
 run-dir parameter.
-\n
+.br
 voacapl --absorption-mode=a ~/itshfbc infile.dat outfile.out
-\n
+.br
 Sets the absorption model used by the prediction to 'a' (Alex's changes with
 IONCAP absorption).  Reads infile.dat and save the results of the calculations
 in the file outfile.out.  Both of the files should be located in the


### PR DESCRIPTION
Hi James! While packaging voacapl for Debian, its package checker (_lintian_) found some warnings caused by voacap manpages:

- `troff` does not allow newline characters in an escape name.
- it treats lines starting with an apostrophe as a control line, that can be followed by a macro call.

This patch, in the case you merge it, replaces lines containing `\n` by `.br`, and uses `\(aq` instead of apostrophes on the beginning of a line.

The warnings emitted by troff can be seen using the following command:

```bash
LC_ALL=C.UTF-8 MANROFFSEQ='' MANWIDTH=80 \
	man --warnings -E UTF-8 -l -Tutf8 -Z man/voacapl.1 > /dev/null
```
