### PR TITLE
Add makeitshfbc manpage

### DIFF
--- a/Makefile.am
+++ b/Makefile.am
@@ -69,7 +69,8 @@ nobase_dist_doc_DATA = \
 
 dist_man_MANS = man/voacapl.1 \
   man/dst2csv.1 \
-	man/dst2ascii.1
+	man/dst2ascii.1 \
+	man/makeitshfbc.1
 
 dist_bin_SCRIPTS = makeitshfbc
 

--- a/man/makeitshfbc.1
+++ b/man/makeitshfbc.1
@@ -1,0 +1,19 @@
+.\" (C) Copyright 2024 David da Silva Polverari <polverari@debian.org>
+.TH VOACAPL 1 "February  12 2024" "Debian Project"
+.SH NAME
+makeitshfbc \- creates the itshfbc directory structure in current user's home directory
+.SH SYNOPSIS
+.B makeitshfbc
+.SH DESCRIPTION
+.PP
+\fBmakeitshfbc\fP  creates a local copy of the itshfbc/ directory structure in
+the current user's home directory.
+.SH AUTHORS
+.PP
+makeitshfbc was written by James Watson <jimwatson@mac.com>.
+.LP
+This manual page was written by David da Silva Polverari <polverari@debian.org>
+for the Debian Project (but may be used by others).
+.SH SEE ALSO
+.BR voacapgui (1),
+.BR voacapl (1)


### PR DESCRIPTION
Hi there again, James! As Debian considers a bug if a program or a utility doesn't have an associated manual page included in the same package or a dependency, I wrote one (really basic) for `makeitshfbc` and included it in the initial packaging. I include it here in this PR for your consideration, to include it as is or modify it as you wish, in the case you use it.